### PR TITLE
Small Fixes After First Site Deployment

### DIFF
--- a/.github/workflows/salesforce.yml
+++ b/.github/workflows/salesforce.yml
@@ -83,3 +83,9 @@ jobs:
             --testlevel=RunLocalTests \
             --sourcepath=force-app \
             --targetusername=devhub
+
+      - name: Publish the Experience Cloud Site
+        run: |
+          sfdx force:community:publish \
+            --targetusername=devhub \
+            --name=Home

--- a/force-app/main/default/experiences/Home1/themes/buildYourOwnLWR.json
+++ b/force-app/main/default/experiences/Home1/themes/buildYourOwnLWR.json
@@ -31,7 +31,7 @@
                   "components": [
                     {
                       "componentAttributes": {
-                        "navigationMenu": "Default_Navigation"
+                        "navigationMenu": "Header_Links"
                       },
                       "componentName": "c:header",
                       "id": "42f6ce03-426b-457e-9597-c6a67e195766",

--- a/force-app/main/default/navigationMenus/External_Links.navigationMenu-meta.xml
+++ b/force-app/main/default/navigationMenus/External_Links.navigationMenu-meta.xml
@@ -2,7 +2,7 @@
 <NavigationMenu xmlns="http://soap.sforce.com/2006/04/metadata">
     <container>Home</container>
     <containerType>Network</containerType>
-    <label>External Links</label>
+    <label>Footer Links</label>
     <navigationMenuItem>
         <label>GitHub</label>
         <position>1</position>

--- a/force-app/main/default/navigationMenus/Header_Links.navigationMenu-meta.xml
+++ b/force-app/main/default/navigationMenus/Header_Links.navigationMenu-meta.xml
@@ -2,7 +2,7 @@
 <NavigationMenu xmlns="http://soap.sforce.com/2006/04/metadata">
     <container>Home</container>
     <containerType>Network</containerType>
-    <label>Default Navigation</label>
+    <label>Header Links</label>
     <navigationMenuItem>
         <label>About</label>
         <position>1</position>


### PR DESCRIPTION
**CICD**
The CICD process deployed new Experience Cloud metadata, but it did not take effect until I went and published the site manually. I found that the `sfdx force:community:publish` command takes care of this for us, so I updated the CICD workflow to also publish the site after it deploys the changes.

**Navigation Menu**
The Navigation Menu was not picked up after the deployment due to a naming conflict in my Dev Org. The Navigation Menu was deployed as Default_Navigation1, which wasn't defined in the ExperienceBundle metadata. I made a new Navigation Menu (Header Links) and used this in the Header. This allowed me to remove the default from source control because we don't use it.