### PR TITLE
Guest User Access to via Sharing Rule

### DIFF
--- a/force-app/main/default/objects/Project__c/Project__c.object-meta.xml
+++ b/force-app/main/default/objects/Project__c/Project__c.object-meta.xml
@@ -156,7 +156,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>false</enableSharing>
     <enableStreamingApi>false</enableStreamingApi>
-    <externalSharingModel>Read</externalSharingModel>
+    <externalSharingModel>Private</externalSharingModel>
     <label>Project</label>
     <nameField>
         <label>Project Name</label>

--- a/force-app/main/default/sharingRules/Project__c.sharingRules-meta.xml
+++ b/force-app/main/default/sharingRules/Project__c.sharingRules-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SharingRules xmlns="http://soap.sforce.com/2006/04/metadata">
+    <sharingGuestRules>
+        <fullName>Guest_User_Read_Only</fullName>
+        <accessLevel>Read</accessLevel>
+        <label>Guest User Read Only</label>
+        <sharedTo>
+            <guestUser>Home</guestUser>
+        </sharedTo>
+        <criteriaItems>
+            <field>Name</field>
+            <operation>notEqual</operation>
+            <value></value>
+        </criteriaItems>
+        <includeHVUOwnedRecords>false</includeHVUOwnedRecords>
+    </sharingGuestRules>
+</SharingRules>


### PR DESCRIPTION
After reviewing the [Secure Guest Users’ Sharing Settings and Record Access](https://help.salesforce.com/s/articleView?id=sf.networks_secure_guest_user_sharing.htm&type=5) article, using a Sharing Rule is a best practice for sharing access to unauthenticated users.