### PR TITLE
Set Project__c External Access to Public

### DIFF
--- a/force-app/main/default/objects/Project__c/Project__c.object-meta.xml
+++ b/force-app/main/default/objects/Project__c/Project__c.object-meta.xml
@@ -156,7 +156,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>false</enableSharing>
     <enableStreamingApi>false</enableStreamingApi>
-    <externalSharingModel>Private</externalSharingModel>
+    <externalSharingModel>Read</externalSharingModel>
     <label>Project</label>
     <nameField>
         <label>Project Name</label>

--- a/force-app/main/default/profiles/Home Profile.profile-meta.xml
+++ b/force-app/main/default/profiles/Home Profile.profile-meta.xml
@@ -97,6 +97,14 @@
         <enabled>false</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>ProjectTriggerHandler</apexClass>
+        <enabled>false</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>ProjectTriggerHandlerTest</apexClass>
+        <enabled>false</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>SiteLoginController</apexClass>
         <enabled>false</enabled>
     </classAccesses>


### PR DESCRIPTION
After watching [Troubleshoot Why a User Can't See a Record: Secure Guest user](https://www.youtube.com/watch?v=ZnmK5qcSmhM), I saw that we need this to be set to Public.