### PR TITLE
Allow Guest Users to View Project Records

### DIFF
--- a/.github/workflows/salesforce.yml
+++ b/.github/workflows/salesforce.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sfdx force:source:deploy \
             --targetusername=scratch-org \
-            --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab
+            --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
 
       - name: Deploy Experience Cloud Metadata
         run: |

--- a/.github/workflows/salesforce.yml
+++ b/.github/workflows/salesforce.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sfdx force:source:deploy \
             --targetusername=scratch-org \
-            --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
+            --metadata=AuraDefinitionBundle,ApexClass,ApexTrigger,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
 
       - name: Deploy Experience Cloud Metadata
         run: |

--- a/bin/install-scratch.bat
+++ b/bin/install-scratch.bat
@@ -39,7 +39,7 @@ timeout 30 > NUL
 echo Deploying base metadata...
 cmd.exe /c sfdx force:source:deploy ^
   --targetusername=%ORG_ALIAS% ^
-  --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab
+  --metadata=AuraDefinitionBundle,ApexClass,ApexTrigger,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
 call :checkForError
 @echo:
 

--- a/bin/install-scratch.sh
+++ b/bin/install-scratch.sh
@@ -39,7 +39,7 @@ echo ""
 echo "Deploying base metadata..."
 sfdx force:source:deploy \
   --targetusername="${ORG_ALIAS}" \
-  --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
+  --metadata=AuraDefinitionBundle,ApexClass,ApexTrigger,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
 echo ""
 
 echo "Deploying Experience site metadata..."

--- a/bin/install-scratch.sh
+++ b/bin/install-scratch.sh
@@ -39,7 +39,7 @@ echo ""
 echo "Deploying base metadata..."
 sfdx force:source:deploy \
   --targetusername="${ORG_ALIAS}" \
-  --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab
+  --metadata=AuraDefinitionBundle,ApexClass,Flexipage,Layout,LightningComponentBundle,CustomObject,PermissionSet,StaticResource,CustomTab,SharingRules
 echo ""
 
 echo "Deploying Experience site metadata..."

--- a/force-app/main/default/experiences/Home1/routes/tooManyRequests.json
+++ b/force-app/main/default/experiences/Home1/routes/tooManyRequests.json
@@ -1,0 +1,10 @@
+{
+  "activeViewId": "2c0f4f0e-1bac-4b0d-aabb-f4adc3e0fdce",
+  "appPageId": "cfd907ec-2754-4dca-845c-05387d321569",
+  "configurationTags": ["allow-in-static-site", "too-many-requests"],
+  "id": "b361284d-1f2a-4c6f-b91a-8b5f83de200f",
+  "label": "Too Many Requests",
+  "routeType": "too-many-requests",
+  "type": "route",
+  "urlPrefix": "too-many-requests"
+}

--- a/force-app/main/default/experiences/Home1/views/tooManyRequests.json
+++ b/force-app/main/default/experiences/Home1/views/tooManyRequests.json
@@ -1,0 +1,60 @@
+{
+  "appPageId": "cfd907ec-2754-4dca-845c-05387d321569",
+  "componentName": "community_layout:sldsFlexibleLayout",
+  "id": "2c0f4f0e-1bac-4b0d-aabb-f4adc3e0fdce",
+  "label": "Too Many Requests",
+  "regions": [
+    {
+      "components": [
+        {
+          "componentAttributes": {
+            "backgroundImageConfig": "",
+            "backgroundImageOverlay": "rgba(0,0,0,0)",
+            "sectionConfig": "{\"UUID\":\"095bc557-ccdf-4e40-a36b-4445f1528933\",\"columns\":[{\"UUID\":\"d8c34d56-c54b-4a9a-885d-f13074604a43\",\"columnName\":\"Column 1\",\"columnKey\":\"col1\",\"columnWidth\":\"12\",\"seedComponents\":null}]}"
+          },
+          "componentName": "community_layout:section",
+          "id": "095bc557-ccdf-4e40-a36b-4445f1528933",
+          "regions": [
+            {
+              "components": [
+                {
+                  "componentAttributes": {
+                    "richTextValue": "<div style=\"display: flex; align-items: center; flex-direction: column; margin: 60px 25px 30px 25px;\">\n\t<div style=\"background-image: url(assets/img/tooManyRequests.svg); background-size: contain; height: 350px; width: 100%; background-repeat: no-repeat; background-position: center;\"></div>\n</div>\n<div style=\"margin: 0 25px; text-align: center;\">\n\t<h1 class=\"slds-text-heading_large\">Looks like the site is experiencing higher than usual demand&#8230;</h1>\n\t<p class=\"slds-text-heading_small\">Don't go anywhere. We'll redirect you in a moment.</p>\n</div>"
+                  },
+                  "componentName": "community_builder:htmlEditor",
+                  "id": "e0e5bc42-ee4c-4466-b3d6-0b669adf72de",
+                  "renderPriority": "NEUTRAL",
+                  "renditionMap": {},
+                  "type": "component"
+                },
+                {
+                  "componentAttributes": {},
+                  "componentName": "experience_availability:autoRefresh",
+                  "id": "cc086c7a-2471-4df7-ad1b-9d7c6f1fb283",
+                  "renderPriority": "NEUTRAL",
+                  "renditionMap": {},
+                  "type": "component"
+                }
+              ],
+              "id": "d8c34d56-c54b-4a9a-885d-f13074604a43",
+              "regionLabel": "Column 1",
+              "regionName": "col1",
+              "renditionMap": {},
+              "type": "region"
+            }
+          ],
+          "renderPriority": "NEUTRAL",
+          "renditionMap": {},
+          "scopedBrandingSetId": null,
+          "type": "component"
+        }
+      ],
+      "id": "c99ff8f9-e05a-470e-942f-b6b8c1a2b41c",
+      "regionName": "content",
+      "type": "region"
+    }
+  ],
+  "themeLayoutType": "ServiceNotAvailable",
+  "type": "view",
+  "viewType": "too-many-requests"
+}

--- a/force-app/main/default/networks/Home.network-meta.xml
+++ b/force-app/main/default/networks/Home.network-meta.xml
@@ -33,7 +33,7 @@
     <gatherCustomerSentimentData>false</gatherCustomerSentimentData>
     <networkMemberGroups>
         <profile>admin</profile>
-    </networkMemberGroups> 
+    </networkMemberGroups>
     <networkPageOverrides>
         <changePasswordPageOverrideSetting
     >Standard</changePasswordPageOverrideSetting>

--- a/force-app/main/default/networks/Home.network-meta.xml
+++ b/force-app/main/default/networks/Home.network-meta.xml
@@ -6,25 +6,25 @@
   >unfiled$public/CommunityChangePasswordEmailTemplate</changePasswordTemplate>
     <communityRoles />
     <disableReputationRecordConversations
-  >true</disableReputationRecordConversations>
+  >false</disableReputationRecordConversations>
     <emailSenderAddress>me@brettbarlow.com</emailSenderAddress>
     <emailSenderName>Home</emailSenderName>
     <enableCustomVFErrorPageOverrides>false</enableCustomVFErrorPageOverrides>
-    <enableDirectMessages>true</enableDirectMessages>
+    <enableDirectMessages>false</enableDirectMessages>
     <enableExperienceBundleBasedSnaOverrideEnabled
   >true</enableExperienceBundleBasedSnaOverrideEnabled>
-    <enableGuestChatter>false</enableGuestChatter>
+    <enableGuestChatter>true</enableGuestChatter>
     <enableGuestFileAccess>false</enableGuestFileAccess>
     <enableGuestMemberVisibility>false</enableGuestMemberVisibility>
     <enableInvitation>false</enableInvitation>
     <enableKnowledgeable>false</enableKnowledgeable>
     <enableMemberVisibility>false</enableMemberVisibility>
-    <enableNicknameDisplay>true</enableNicknameDisplay>
+    <enableNicknameDisplay>false</enableNicknameDisplay>
     <enablePrivateMessages>false</enablePrivateMessages>
     <enableReputation>false</enableReputation>
     <enableShowAllNetworkSettings>false</enableShowAllNetworkSettings>
     <enableSiteAsContainer>true</enableSiteAsContainer>
-    <enableTalkingAboutStats>true</enableTalkingAboutStats>
+    <enableTalkingAboutStats>false</enableTalkingAboutStats>
     <enableTopicAssignmentRules>true</enableTopicAssignmentRules>
     <enableTopicSuggestions>false</enableTopicSuggestions>
     <enableUpDownVote>false</enableUpDownVote>
@@ -33,7 +33,7 @@
     <gatherCustomerSentimentData>false</gatherCustomerSentimentData>
     <networkMemberGroups>
         <profile>admin</profile>
-    </networkMemberGroups>
+    </networkMemberGroups> 
     <networkPageOverrides>
         <changePasswordPageOverrideSetting
     >Standard</changePasswordPageOverrideSetting>


### PR DESCRIPTION
- Updated scripts that make Scratch Orgs to include Sharing Rules and Apex Triggers when building orgs.
    - The Sharing Rule is needed to grant Guest Users access. I forgot to include the Apex Trigger and it caused the Done__c field to not be populated when sample data was imported.
- Retrieved metadata for the Experience Cloud site. It's not clear what sets the `Allow guest users to access public APIs` checkbox in the Experience Cloud site's admin page so I included ExperienceBundle, CustomSite and Network.

<img width="537" alt="Screen Shot 2022-06-06 at 2 25 15 PM" src="https://user-images.githubusercontent.com/19278923/172253403-851ef06c-43b5-42f7-8245-b3feaf749d04.png">
