### PR TITLE
Pass with no LWC Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:apex": "sfdx force:apex:test:run --testlevel=RunLocalTests --wait=10",
     "test:apex:coverage": "sfdx force:apex:test:run --testlevel=RunLocalTests --wait=10 --codecoverage --detailedcoverage --outputdir=coverage/apex --resultformat=human",
     "test:lwc": "sfdx-lwc-jest -- --passWithNoTests",
-    "test:lwc:coverage": "sfdx-lwc-jest --coverage"
+    "test:lwc:coverage": "sfdx-lwc-jest --coverage -- --passWithNoTests"
   },
   "devDependencies": {
     "@lwc/eslint-plugin-lwc": "^1.3.0",


### PR DESCRIPTION
Adding this flag for now and let's remove it after adding some LWC tests.

It's causing the Code Coverage workflow to fail: https://github.com/thebrettbarlow/brettbarlow-dev-ed/runs/6840289541?check_suite_focus=true