### PR TITLE
Clean Up and Fixes for Resume as LWC

### DIFF
--- a/force-app/main/default/cspTrustedSites/www_google_analytics_com.cspTrustedSite-meta.xml
+++ b/force-app/main/default/cspTrustedSites/www_google_analytics_com.cspTrustedSite-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CspTrustedSite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <context>Communities</context>
+    <description>www_google_analytics_com Trusted Site Added Via Community Builder</description>
+    <endpointUrl>https://www.google-analytics.com</endpointUrl>
+    <isActive>true</isActive>
+    <isApplicableToConnectSrc>true</isApplicableToConnectSrc>
+    <isApplicableToFontSrc>true</isApplicableToFontSrc>
+    <isApplicableToFrameSrc>true</isApplicableToFrameSrc>
+    <isApplicableToImgSrc>true</isApplicableToImgSrc>
+    <isApplicableToMediaSrc>true</isApplicableToMediaSrc>
+    <isApplicableToStyleSrc>true</isApplicableToStyleSrc>
+</CspTrustedSite>

--- a/force-app/main/default/experiences/Home1/views/resume.json
+++ b/force-app/main/default/experiences/Home1/views/resume.json
@@ -19,7 +19,7 @@
               "components": [
                 {
                   "componentAttributes": {
-                    "resumeName": ""
+                    "resumeName": "Salesforce Engineer"
                   },
                   "componentName": "c:resumeContainer",
                   "id": "03b7a320-7e60-4371-a6cb-00abc49dd8a6",

--- a/force-app/main/default/objects/Resume_Entry__c/fields/Skills__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume_Entry__c/fields/Skills__c.field-meta.xml
@@ -9,7 +9,7 @@
     <type>MultiselectPicklist</type>
     <valueSet>
         <valueSetDefinition>
-            <sorted>true</sorted>
+            <sorted>false</sorted>
             <value>
                 <fullName>Apex</fullName>
                 <default>false</default>

--- a/force-app/main/default/objects/Resume__c/fields/Salesforce_Certifications__c.field-meta.xml
+++ b/force-app/main/default/objects/Resume__c/fields/Salesforce_Certifications__c.field-meta.xml
@@ -9,7 +9,7 @@
     <type>MultiselectPicklist</type>
     <valueSet>
         <valueSetDefinition>
-            <sorted>true</sorted>
+            <sorted>false</sorted>
             <value>
                 <fullName>Administrator</fullName>
                 <default>false</default>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "prepare": "husky install",
     "prettier": "prettier --write '**/*.{cls,trigger}' '**/lwc/**/*.{css,html,js}' '**/*.{json,md,yml}'",
     "sf:open": "sfdx force:org:open",
+    "sf:retrieve": "sfdx force:source:retrieve",
+    "sf:retrieve:community": "sfdx force:source:retrieve --metadata=ExperienceBundle,Network,CustomSite,NavigationMenu,CspTrustedSite",
     "sf:validate": "sfdx force:source:deploy --checkonly --sourcepath=force-app --testlevel=RunLocalTests --wait=10",
     "test:apex": "sfdx force:apex:test:run --testlevel=RunLocalTests --wait=10",
     "test:apex:coverage": "sfdx force:apex:test:run --testlevel=RunLocalTests --wait=10 --codecoverage --detailedcoverage --outputdir=coverage/apex --resultformat=human",


### PR DESCRIPTION
- The resume name could not be defined during the initial deployment, so this defines it
- Added the Google Analytics domain to the list of trusted sites
- Ordered the picklists alphabetically
- Includes some package.json scripts to retrieve metadata