### PR TITLE
Show Spinner until Resume Loads

### DIFF
--- a/force-app/main/default/lwc/resume/resume.html
+++ b/force-app/main/default/lwc/resume/resume.html
@@ -1,4 +1,13 @@
 <template>
+  <!-- TODO: Spinner shows over the error.
+        Consider making a utility component that handles this.-->
+  <template if:false={resume.data}>
+    <lightning-spinner
+      alternative-text="Loading"
+      variant="brand"
+      size="medium"
+    ></lightning-spinner>
+  </template>
   <template if:true={resume.error}>{resume.error}</template>
   <template if:true={resume.data}>
     <div class="slds-grid slds-grid_align-center">

--- a/force-app/main/default/lwc/resume/resume.js
+++ b/force-app/main/default/lwc/resume/resume.js
@@ -39,10 +39,6 @@ export default class Resume extends LightningElement {
   })
   resume;
 
-  get isResumeLoaded() {
-    return this.resume;
-  }
-
   @wire(getUniqueSkillsFromResumeEntries, { resumeId: '$recordId' })
   skills;
 

--- a/force-app/main/default/lwc/resume/resume.js
+++ b/force-app/main/default/lwc/resume/resume.js
@@ -39,6 +39,10 @@ export default class Resume extends LightningElement {
   })
   resume;
 
+  get isResumeLoaded() {
+    return this.resume;
+  }
+
   @wire(getUniqueSkillsFromResumeEntries, { resumeId: '$recordId' })
   skills;
 


### PR DESCRIPTION
The [resume page](https://brettbarlow-dev-ed.my.site.com/resume) seems to take a little bit to load so let's show a spinner until the @wire retrieves the data. This isn't a perfect solution because the spinner will show over any error message, but let's build a utility component to handle this more gracefully.