### PR TITLE
Skip Publishing Experience Site on Scheduled CI Jobs

### DIFF
--- a/.github/workflows/salesforce-ci.yml
+++ b/.github/workflows/salesforce-ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Get Changed Experience Cloud Metadata
         id: changed-experience-cloud-metadata
+        if: ${{ github.event_name != 'schedule' }}
         uses: tj-actions/changed-files@v22.2
         with:
           files: |


### PR DESCRIPTION
The [salesforce-ci.yml](https://github.com/thebrettbarlow/brettbarlow-dev-ed/blob/main/.github/workflows/salesforce-ci.yml) job deploys [force-app](https://github.com/thebrettbarlow/brettbarlow-dev-ed/tree/main/force-app) to the org and then checks for Experience Cloud metadata changes so that it can publish an update to the site if needed.

Let's not do this on scheduled jobs because the site will get updated after PR merges and the confirmation email about the site being updated every night are annoying.